### PR TITLE
fix(extension): allow configuration of chrome binaries via env file

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -18,6 +18,7 @@ AI-powered browser assistant with Model Context Protocol integration for enhance
    - `VITE_CHAT_API_URL`: (Optional) Override the full chat API URL
    - `VITE_ENABLE_DEBUG_LOGGING`: Enable debug logging (default: false)
    - `VITE_MAX_CHAT_STEPS`: Maximum chat steps (default: 5)
+   - `CHROME_PATH`: (Optional) Path to Chrome binary for development testing
 
 ### Running the Extension
 

--- a/extension/env.example
+++ b/extension/env.example
@@ -2,8 +2,8 @@
 # Copy this file to .env for local development
 
 # API Configuration
-VITE_API_BASE_URL=https://...
-VITE_API_CHAT_ENDPOINT=/api/chat
+# VITE_API_BASE_URL=https://...
+# VITE_API_CHAT_ENDPOINT=/api/chat
 
 # Optional: Override the full chat API URL (takes precedence over BASE_URL + CHAT_ENDPOINT)
 # VITE_CHAT_API_URL=https://..../api/chat
@@ -11,3 +11,9 @@ VITE_API_CHAT_ENDPOINT=/api/chat
 # Feature Flags (optional)
 # VITE_ENABLE_DEBUG_LOGGING=false
 # VITE_MAX_CHAT_STEPS=5 
+
+# Path to Chrome instances
+# Windows (standard location)
+# CHROME_PATH=C:\Program Files\Google\Chrome\Application\chrome.exe
+# macOS (standard):
+# CHROME_PATH=/Applications/Google Chrome.app/Contents/MacOS/Google Chrome

--- a/extension/web-ext.config.ts
+++ b/extension/web-ext.config.ts
@@ -3,8 +3,8 @@ import { defineWebExtConfig } from 'wxt';
 export default defineWebExtConfig({
   // Use persistent user data directory so native messaging manifests are found
   chromiumArgs: ['--user-data-dir=./.wxt/chrome-data'],
-  // Optional: Set Chrome for Testing binary if available
-  // binaries: {
-  //   chrome: '/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing',
-  // },
+  // Set Chrome binary path from environment variable
+  binaries: process.env.CHROME_PATH ? {
+    chrome: process.env.CHROME_PATH,
+  } : undefined,
 });


### PR DESCRIPTION
A fix for the issue discussed [here](https://github.com/MiguelsPizza/WebMCP/issues/13)

I commented out in env.example
```
# VITE_API_BASE_URL=https://...
# VITE_API_CHAT_ENDPOINT=/api/chat
```
Since I didn't want to override the defaults in the instructions for the README to set the CHROM_PATH. Let me know if this is an issue or not.