### PR TITLE
docs(global): simplified claude desktop instructions, fix package name

### DIFF
--- a/ConnectingTOClaudeDesktop.md
+++ b/ConnectingTOClaudeDesktop.md
@@ -1,56 +1,37 @@
 ### Connecting to Claude Desktop (via Proxy)
 
-Claude Desktop primarily expects MCP servers via stdio transport. Since the native host exposes a Streamable HTTP endpoint (at `http://127.0.0.1:12306/mcp` by default), you'll need to use `mcp-proxy` to bridge this to stdio.
+Claude Desktop primarily expects MCP servers via stdio transport. Since the native host exposes a Streamable HTTP endpoint (at `http://127.0.0.1:12306/mcp` by default), you'll need to use `mcp-remote` to bridge this to stdio.
 
-#### Step 1: Install mcp-proxy
-Install `mcp-proxy` globally using a Python tool installer (requires Python 3.8+). Recommended: Use `uv` for speed (install via `brew install uv` on macOS or equivalent).
-
-```bash
-uv tool install mcp-proxy
-```
-
-Alternative (using `pipx`):
-```bash
-pipx install mcp-proxy
-```
+#### Step 1: Make sure npx/npm is installed
+Install npm if needed
 
 Verify installation:
 ```bash
-mcp-proxy --help
+npx --version
 ```
 
-#### Step 2: Find the Full Path to mcp-proxy
-Claude Desktop may not find `mcp-proxy` in your PATH, so use the full binary path in your config.
-
-Run:
-```bash
-which mcp-proxy
-```
-This typically outputs something like `/Users/yourusername/.local/bin/mcp-proxy`. Note this path.
-
-#### Step 3: Configure in Claude Desktop
+#### Step 2: Configure in Claude Desktop
 Open Claude Desktop > **Settings** > **Developer** > **Edit Config** (or manually edit `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS).
 
-Add or merge this under `"mcpServers"` (replace `/path/to/mcp-proxy` with your full path from Step 2, and adjust the URL/port if your native host uses a custom one):
+Add or merge this under `"mcpServers"` (adjust the URL/port if your native host uses a custom one):
 
 ```json
 {
-  "mcpServers": {
-    "mcp-b-proxy": {
-      "command": "/path/to/mcp-proxy",
-      "args": [
-        "http://127.0.0.1:12306/mcp",
-        "--transport=streamablehttp"
-      ],
-      "env": {}
+    "mcpServers": {
+        "mcp-b-proxy": {
+            "command": "npx",
+            "args": [
+                "mcp-remote",
+                "http://127.0.0.1:12306/mcp"
+            ]
+        }
     }
-  }
 }
 ```
 
 Save and restart Claude Desktop. The proxy will start automatically when Claude needs it.
 
-#### Step 4: Test the Connection
+#### Step 3: Test the Connection
 - Ensure the native host is running (`@mcp-b/native-host`) and your MCP-enabled site is open in Chrome with the extension.
 - In Claude Desktop, open **Developer Tools** > **MCP Inspector** and test calling tools (they'll be prefixed with your site's domain).
 - Check Claude's logs for errors (via console or file). If you see "ENOENT", double-check the full path in your config.

--- a/README.md
+++ b/README.md
@@ -261,15 +261,15 @@ For the latest features or custom modifications:
 
 Run in dev mode for hot reloading: `pnpm --filter extension dev`.
 
-## Hooking Up the Native Host
+## Hooking Up the Native Server
 
-To connect MCP-B to local MCP clients (e.g., Claude Desktop, Cursor) via a native host, bridging the browser to local processes:
+To connect MCP-B to local MCP clients (e.g., Claude Desktop, Cursor) via a native server, bridging the browser to local processes:
 
 > IMPORTANT: You will need to disable the chrome webstore version of the extension if you have it downloaded.
 > Failure to do so will cause port clashing when the dev and prod extension run
 
-1. Install globally: `npm install -g @mcp-b/native-host`.
-2. Run the host: `@mcp-b/native-host` (starts a server on port 12306 by default).
+1. Install globally: `npm install -g @mcp-b/native-server`.
+2. Run the host: `@mcp-b/native-server` (starts a server on port 12306 by default).
 
 Add this configuration to your MCP client (e.g., in Claude's config or Cursor's `.cursor/mcp.json`):
 
@@ -281,7 +281,7 @@ Add this configuration to your MCP client (e.g., in Claude's config or Cursor's 
 }
 ```
 
-- **What this does**: The native host proxies requests from local clients to the browser extension, allowing tools from your website to be called from desktop apps.
+- **What this does**: The native server proxies requests from local clients to the browser extension, allowing tools from your website to be called from desktop apps.
 - **Note**: The native server is based on [mcp-chrome](https://github.com/hangwin/mcp-chrome) by [hangwin](https://github.com/hangwin). Ensure the extension is running and tabs with your site are open.
 
 Test by running a local client (e.g., MCP Inspector) pointed at the URL, then calling tools from your site.


### PR DESCRIPTION
Simplified Claude desktop instructions to just use
```json
{
    "mcpServers": {
        "mcp-b": {
            "command": "npx",
            "args": [
                "mcp-remote",
                "http://127.0.0.1:12306/mcp"
            ]
        }
    }
}
```

Fixed the name of the package in main README