### PR TITLE
show tool call arguments

### DIFF
--- a/apps/extension/entrypoints/sidepanel/components/assistant-ui/McpToolUIRenderer.tsx
+++ b/apps/extension/entrypoints/sidepanel/components/assistant-ui/McpToolUIRenderer.tsx
@@ -35,7 +35,7 @@ const FancyToolRenderer = ({ tool }: { tool: McpTool }) => {
       // }
 
       if (status.type === 'incomplete' && status.reason === 'error') {
-        return <ToolErrorUI tool={tool} status={status} />;
+        return <ToolErrorUI tool={tool} status={status} args={args} />;
       }
 
       if (status.type === 'complete') {
@@ -47,7 +47,7 @@ const FancyToolRenderer = ({ tool }: { tool: McpTool }) => {
             reason: 'error',
             error: new Error(errorText),
           };
-          return <ToolErrorUI tool={tool} status={errorStatus} />;
+          return <ToolErrorUI tool={tool} status={errorStatus} args={args} />;
         }
 
         // Fallback: Check if the result content contains error messages (for legacy compatibility)
@@ -65,10 +65,10 @@ const FancyToolRenderer = ({ tool }: { tool: McpTool }) => {
             reason: 'error',
             error: new Error(resultText),
           };
-          return <ToolErrorUI tool={tool} status={errorStatus} />;
+          return <ToolErrorUI tool={tool} status={errorStatus} args={args} />;
         }
 
-        return <ToolSuccessUI tool={tool} result={result} />;
+        return <ToolSuccessUI tool={tool} result={result} args={args} />;
       }
 
       return null;


### PR DESCRIPTION
We now show the arguments that were passed into tool calls.

<img width="655" height="824" alt="image" src="https://github.com/user-attachments/assets/407a1ee3-c9cb-4e07-801b-429e29a2f7b4" />
