### PR TITLE
fix: add auto-build check to prevent postinstall errors for new users

### DIFF
--- a/apps/native-server/package.json
+++ b/apps/native-server/package.json
@@ -10,7 +10,7 @@
     "dev": "nodemon --watch src --ext ts,js,json --ignore dist/ --exec \"npm run build && npm run register:dev\"",
     "build": "ts-node src/scripts/build.ts",
     "register:dev": "node dist/scripts/register-dev.js",
-    "postinstall": "node dist/scripts/postinstall.js",
+    "postinstall": "node src/scripts/check-and-build.js && node dist/scripts/postinstall.js",
     "prepare:publish": "node ../scripts/replace-workspace-deps.cjs ./package.json",
     "prepublishOnly": "pnpm run build",
     "publish:npm": "npm publish --access public --no-git-checks",

--- a/apps/native-server/src/scripts/check-and-build.js
+++ b/apps/native-server/src/scripts/check-and-build.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Check if dist directory exists
+const distPath = path.join(__dirname, '..', '..', 'dist');
+
+if (!fs.existsSync(distPath)) {
+  console.log('📦 dist directory not found, building project...');
+  try {
+    execSync('npm run build', { stdio: 'inherit', cwd: path.join(__dirname, '..', '..') });
+    console.log('✅ Build completed successfully');
+  } catch (error) {
+    console.error('❌ Build failed:', error.message);
+    process.exit(1);
+  }
+} else {
+  console.log('✅ dist directory exists, skipping build');
+}


### PR DESCRIPTION
- Add check-and-build.js script to auto-build when dist/ is missing
- Update native-server postinstall script to use auto-build mechanism
- Prevents MODULE_NOT_FOUND errors during fresh installs
- Cross-platform compatible (Windows, macOS, Linux)
- Provides clear console feedback during build process